### PR TITLE
Set responsive true for GH Calendar

### DIFF
--- a/about.html
+++ b/about.html
@@ -298,8 +298,6 @@
 						Loading the data just for you.
 					</div>
 					<script>
-						GitHubCalendar(".calendar", "pranav6670");
-						// or enable responsive functionality
 						GitHubCalendar(".calendar", "pranav6670", { responsive: true });
 					</script>
 				</section>


### PR DESCRIPTION
Lol you probably want it as true. Otherwise it causes a horizontal scroll on mobile. Es sieht nicht so gut oder.