### PR TITLE
cat: friendly aliases — social, projects, and .txt-less names

### DIFF
--- a/js/terminal-core.js
+++ b/js/terminal-core.js
@@ -172,8 +172,10 @@
     },
     cat: function (arg) {
       if (!arg) return out([[mut("usage: cat <file> — try:")], [mut(FILE_NAMES.join("  "))]]);
-      if (arg === ".social" || arg === "~/.social") return out(socialLines());
+      if (arg === ".social" || arg === "~/.social" || arg === "social") return out(socialLines());
+      if (arg === "projects" || arg === "projects/" || arg === "~/projects") return out(projectLines());
       if (FILES[arg]) return out(FILES[arg]);
+      if (FILES[arg + ".txt"]) return out(FILES[arg + ".txt"]);
       return out([[err("cat: " + arg + ": No such file")]]);
     },
     echo: function (arg) { return out(arg ? [[t(arg)]] : [[t("")]]); },

--- a/tests/terminal-core.test.mjs
+++ b/tests/terminal-core.test.mjs
@@ -79,6 +79,14 @@ test("cat prints files; social file has real links", () => {
   assert.ok(hrefs.some((h) => h.includes("linkedin.com")));
 });
 
+test("cat friendly aliases: social and projects work without exact filenames", () => {
+  const socialHrefs = Core.run("cat social").lines.flat().filter((s) => s.href).map((s) => s.href);
+  assert.ok(socialHrefs.some((h) => h.includes("github.com/pranav6670")), "cat social lists socials");
+  const cp = Core.run("cat projects");
+  const projHrefs = cp.lines.flat().filter((s) => s.href).map((s) => s.href);
+  assert.ok(projHrefs.some((h) => h === "projects/tabla-tala.html"), "cat projects lists projects");
+});
+
 test("topic commands mirror files", () => {
   for (const c of ["about", "experience", "education", "research", "interests"])
     assert.ok(Core.run(c).lines.length > 0, `${c} should print`);


### PR DESCRIPTION
cat social ≡ cat .social; cat projects lists the projects; cat about works without the .txt suffix.