### PR TITLE
Real subpages (projects/, blog/), facts-table UX fix, drop More info

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Blog &mdash; Pranav Natekar</title>
+  <meta name="description" content="Writing by Pranav Natekar — image processing, computer vision, audio classification, and RISC-V, published on Medium.">
+  <link rel="shortcut icon" href="../images/favicon.ico" type="image/x-icon">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/site.css">
+</head>
+
+<body id="top">
+
+  <header class="nav">
+    <div class="nav__inner">
+      <a class="nav__brand" href="../index.html">Pranav Natekar</a>
+      <nav class="nav__menu nav__menu--static">
+        <a href="../index.html">About</a>
+        <a href="../projects/">Projects</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="article">
+    <a class="article__back" href="../index.html">&larr; back to home</a>
+    <h1 class="article__title">Blog</h1>
+    <ul class="feed">
+      <li class="feed__item">
+        <a class="feed__link" href="https://pranavnatekar.medium.com/cross-compile-opencv-for-risc-v-460305012adb" target="_blank" rel="noopener noreferrer">
+          <span class="feed__meta">Medium &middot; Aug 26, 2021</span>
+          <h2 class="feed__title">Cross Compile OpenCV for RISC-V</h2>
+          <p class="feed__desc">Getting OpenCV built and running for RISC-V targets, step by step.</p>
+        </a>
+      </li>
+      <li class="feed__item">
+        <a class="feed__link" href="https://pranavnatekar.medium.com/a-comprehensive-and-practical-guide-to-image-processing-and-computer-vision-using-python-part-1-4d8283c6d6eb" target="_blank" rel="noopener noreferrer">
+          <span class="feed__meta">Medium &middot; Oct 26, 2019</span>
+          <h2 class="feed__title">A Practical Guide to Image Processing &amp; Computer Vision Using Python &mdash; Part 1</h2>
+          <p class="feed__desc">Fundamentals of image processing and computer vision, hands-on in Python.</p>
+        </a>
+      </li>
+      <li class="feed__item">
+        <a class="feed__link" href="https://pranavnatekar.medium.com/tackle-almost-any-audio-classification-challenge-with-this-34a1d0ac82b9" target="_blank" rel="noopener noreferrer">
+          <span class="feed__meta">Medium &middot; Aug 18, 2019</span>
+          <h2 class="feed__title">Tackle Almost Any Audio Classification Challenge with This!!</h2>
+          <p class="feed__desc">A practical recipe for audio classification problems.</p>
+        </a>
+      </li>
+    </ul>
+    <p class="article__more">All posts live on <a href="https://pranavnatekar.medium.com/" target="_blank" rel="noopener noreferrer">Medium &#8599;</a></p>
+  </main>
+
+  <footer class="footer">
+    <div class="container footer__inner">
+      <ul class="footer__social">
+        <li><a href="https://github.com/pranav6670" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+        <li><a href="https://www.linkedin.com/in/pranavnatekar/" target="_blank" rel="noopener noreferrer">LinkedIn</a></li>
+        <li><a href="https://twitter.com/pranavnat24" target="_blank" rel="noopener noreferrer">Twitter</a></li>
+      </ul>
+      <p class="footer__copy">&copy; 2026 Pranav Natekar</p>
+    </div>
+  </footer>
+
+  <script src="../js/site.js"></script>
+</body>
+
+</html>

--- a/css/site.css
+++ b/css/site.css
@@ -113,11 +113,13 @@ h1, h2, h3, h4 {
 .article__back { font-family: var(--font-mono); font-size: 0.875rem; color: var(--muted); display: inline-block; margin-bottom: 2.5rem; }
 .article__back:hover { color: var(--fg); }
 .article__title { font-size: clamp(2.4rem, 5vw, 3.75rem); line-height: 1.25; margin-bottom: 1.5rem; }
-.article__facts { display: grid; grid-template-columns: 8.5rem 1fr; row-gap: 0.4rem; margin: 0 0 2.5rem; font-family: var(--font-mono); font-size: 0.875rem; color: var(--fg); }
-.article__facts dt { font-weight: 400; }
+.article__facts { display: grid; grid-template-columns: 7.5rem 1fr; row-gap: 0.5rem; align-items: baseline; margin: 0 0 2.5rem; font-family: var(--font-mono); font-size: 0.875rem; color: var(--fg); }
+.article__facts dt { font-size: 0.72rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); }
 .article__facts dd { margin: 0; }
 .article__facts a { text-decoration: underline; text-underline-offset: 3px; }
 .article__facts a:hover { color: var(--muted); }
+.article__more { font-family: var(--font-mono); font-size: 0.875rem; color: var(--muted); margin-top: 2.5rem; }
+.article__more a { color: var(--fg); text-decoration: underline; text-underline-offset: 3px; }
 .article__figure { width: min(1000px, 92vw); margin: 2.5rem 0 2.5rem 50%; transform: translateX(-50%); }
 .article__figure img { border: 0; border-radius: 8px; }
 .article p { margin-bottom: 1rem; line-height: 1.625; }

--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
             <p>Pranav Natekar &mdash; software engineer working across machine learning, computer vision and speech.
               This site is an interactive terminal and needs JavaScript; the essentials:</p>
             <ul>
+              <li><a href="projects/">All projects</a> &middot; <a href="blog/">Blog</a></li>
               <li><a href="projects/tabla-tala.html">Automatic Detection &amp; Classification of Tabla Talas</a></li>
               <li><a href="projects/autonomous-vehicle.html">Autonomous Vehicle Drive</a></li>
               <li><a href="projects/image-augmenter.html">Image Augmenter</a></li>

--- a/js/terminal-core.js
+++ b/js/terminal-core.js
@@ -40,6 +40,12 @@
     { slug: "bag-ewatch", title: "Bag eWatch", meta: "Hardware · Embedded" }
   ];
 
+  var BLOG = [
+    { title: "Cross Compile OpenCV for RISC-V", date: "Aug 2021", href: "https://pranavnatekar.medium.com/cross-compile-opencv-for-risc-v-460305012adb" },
+    { title: "A Practical Guide to Image Processing & Computer Vision — Part 1", date: "Oct 2019", href: "https://pranavnatekar.medium.com/a-comprehensive-and-practical-guide-to-image-processing-and-computer-vision-using-python-part-1-4d8283c6d6eb" },
+    { title: "Tackle Almost Any Audio Classification Challenge", date: "Aug 2019", href: "https://pranavnatekar.medium.com/tackle-almost-any-audio-classification-challenge-with-this-34a1d0ac82b9" }
+  ];
+
   var FILES = {
     "about.txt": [
       [t("Engineer working across machine learning, computer vision and speech.")],
@@ -78,21 +84,28 @@
     [t("→ Research  : "), link("brain.lab @ RIT", "https://www.rit.edu/kgcoe/brainlab/"), t(" — speech tech for atypical speech")]
   ];
 
-  function pageLines() {
-    var lines = PROJECTS.map(function (p) {
-      return [t("📄 "), link(p.title, "projects/" + p.slug + ".html")];
+  function blogLines() {
+    var lines = BLOG.map(function (b) {
+      return [t("→ "), link(b.title, b.href), mut("  (" + b.date + ")")];
     });
-    lines.push([t("📂 "), link("writing/", MEDIUM), mut("  (Medium)")]);
+    lines.push([mut("everything lives on "), link("Medium", MEDIUM)]);
     return lines;
+  }
+
+  function pageLines() {
+    return [
+      [t("📂 "), link("projects/", "projects/")],
+      [t("📂 "), link("blog/", "blog/")]
+    ];
   }
 
   function intro() {
     return [
       { cmd: "$ echo $GREETING", lines: [[t("\"नमस्ते — welcome to my corner of the web.\"")]] },
       { cmd: "# cat /proc/status", lines: STATUS },
-      { cmd: "# ls ~/projects/", lines: pageLines() },
+      { cmd: "# ls ~/pages/", lines: pageLines() },
       { cmd: "# cat ~/.social", lines: socialLines() },
-      { cmd: null, lines: [[mut("Type "), gold("help"), mut(" for commands — try whoami, projects, or open tabla-tala.")]] }
+      { cmd: null, lines: [[mut("Type "), gold("help"), mut(" for commands — try whoami, projects, or cd blog.")]] }
     ];
   }
 
@@ -118,9 +131,10 @@
     ["whoami", "one-line intro"],
     ["about", "who I am (also: experience, education, research, interests)"],
     ["projects", "list my projects"],
+    ["blog", "my writing (Medium)"],
     ["open <slug>", "read a project write-up"],
-    ["ls", "list directories & files"],
-    ["cd <dir>", "go places (projects, projects/<slug>, writing)"],
+    ["ls", "list pages & files"],
+    ["cd <page>", "go to a page (projects, blog, projects/<slug>)"],
     ["cat <file>", "print a file (about.txt … .social)"],
     ["social", "where to find me"],
     ["echo <text>", "say it back"],
@@ -146,23 +160,25 @@
     research: function () { return out(FILES["research.txt"]); },
     interests: function () { return out(FILES["interests.txt"]); },
     projects: function () { return out(projectLines()); },
+    blog: function () { return out(blogLines()); },
     social: function () { return out(socialLines()); },
     contact: function () { return out(socialLines()); },
     ls: function () {
       return out([
-        [gold("projects/"), t("  "), link("writing/", MEDIUM)],
+        [link("projects/", "projects/"), t("  "), link("blog/", "blog/")],
         [mut(FILE_NAMES.join("  "))]
       ]);
     },
     cd: function (arg) {
       if (!arg || arg === "~" || arg === "/") return out([], { type: "scroll", target: "#top" });
-      if (arg === "projects" || arg === "projects/") return out(projectLines());
+      if (arg === "projects" || arg === "projects/") return out([], { type: "navigate", href: "projects/", newTab: false });
+      if (arg === "blog" || arg === "blog/") return out([], { type: "navigate", href: "blog/", newTab: false });
       if (arg === "writing" || arg === "writing/") return out([], { type: "navigate", href: MEDIUM, newTab: true });
       var m = /^projects\/([\w-]+)\/?$/.exec(arg);
       if (m && findProject(m[1])) return out([], { type: "navigate", href: "projects/" + m[1] + ".html", newTab: false });
       return out([
         [err("cd: no such directory: " + arg)],
-        [mut("directories: projects/  writing/  projects/<slug> — files: try cat about.txt")]
+        [mut("pages: projects/  blog/  projects/<slug> — files: try cat about.txt")]
       ]);
     },
     open: function (arg) {
@@ -174,6 +190,7 @@
       if (!arg) return out([[mut("usage: cat <file> — try:")], [mut(FILE_NAMES.join("  "))]]);
       if (arg === ".social" || arg === "~/.social" || arg === "social") return out(socialLines());
       if (arg === "projects" || arg === "projects/" || arg === "~/projects") return out(projectLines());
+      if (arg === "blog" || arg === "blog/" || arg === "~/blog") return out(blogLines());
       if (FILES[arg]) return out(FILES[arg]);
       if (FILES[arg + ".txt"]) return out(FILES[arg + ".txt"]);
       return out([[err("cat: " + arg + ": No such file")]]);
@@ -209,10 +226,10 @@
 
   /* Commands offered by tab completion / suggested publicly (easter eggs excluded). */
   var PUBLIC_COMMANDS = ["help", "whoami", "about", "experience", "education", "research",
-    "interests", "projects", "open", "ls", "cd", "cat", "social", "contact", "echo",
+    "interests", "projects", "blog", "open", "ls", "cd", "cat", "social", "contact", "echo",
     "pwd", "date", "banner", "history", "clear"];
   var ARG_COMPLETIONS = {
-    cd: ["projects", "writing"].concat(slugs().map(function (s) { return "projects/" + s; })),
+    cd: ["projects", "blog", "writing"].concat(slugs().map(function (s) { return "projects/" + s; })),
     open: slugs(),
     cat: FILE_NAMES
   };

--- a/projects/autonomous-vehicle.html
+++ b/projects/autonomous-vehicle.html
@@ -48,7 +48,6 @@
       <li>On-board compute &mdash; Raspberry Pi 3 with camera</li>
     </ul>
     <div class="article__actions">
-      <a class="btn" href="https://pranav6670.github.io/Autonomous-Vehicle-Drive/" target="_blank" rel="noopener noreferrer">More info</a>
       <a class="btn" href="https://github.com/pranav6670/Autonomous-Vehicle-Drive" target="_blank" rel="noopener noreferrer">See on GitHub</a>
     </div>
   </main>

--- a/projects/bag-ewatch.html
+++ b/projects/bag-ewatch.html
@@ -47,7 +47,6 @@
       <li>Libraries &mdash; ESP8266WiFi, U8g2lib, Wire, Adafruit_BMP085, Geometry, SPI</li>
     </ul>
     <div class="article__actions">
-      <a class="btn" href="https://pranav6670.github.io/ePaper-Watch/" target="_blank" rel="noopener noreferrer">More info</a>
       <a class="btn" href="https://github.com/pranav6670/ePaper-Watch" target="_blank" rel="noopener noreferrer">See on GitHub</a>
     </div>
   </main>

--- a/projects/index.html
+++ b/projects/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Projects &mdash; Pranav Natekar</title>
+  <meta name="description" content="Projects by Pranav Natekar — machine learning, computer vision, audio, and embedded hardware.">
+  <link rel="shortcut icon" href="../images/favicon.ico" type="image/x-icon">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/site.css">
+</head>
+
+<body id="top">
+
+  <header class="nav">
+    <div class="nav__inner">
+      <a class="nav__brand" href="../index.html">Pranav Natekar</a>
+      <nav class="nav__menu nav__menu--static">
+        <a href="../index.html">About</a>
+        <a href="../blog/">Blog</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="article">
+    <a class="article__back" href="../index.html">&larr; back to home</a>
+    <h1 class="article__title">Projects</h1>
+    <ul class="feed">
+      <li class="feed__item">
+        <a class="feed__link" href="tabla-tala.html">
+          <span class="feed__meta">Machine Learning &middot; Audio</span>
+          <h2 class="feed__title">Automatic Detection &amp; Classification of Tabla Talas</h2>
+          <p class="feed__desc">Detecting and classifying tabla talas from Indian classical music. Winner, TensorFlow Community Spotlight.</p>
+        </a>
+      </li>
+      <li class="feed__item">
+        <a class="feed__link" href="autonomous-vehicle.html">
+          <span class="feed__meta">Robotics &middot; Deep Learning</span>
+          <h2 class="feed__title">Autonomous Vehicle Drive</h2>
+          <p class="feed__desc">A vehicle built from scratch and driven autonomously with a multilayer perceptron over live video.</p>
+        </a>
+      </li>
+      <li class="feed__item">
+        <a class="feed__link" href="image-augmenter.html">
+          <span class="feed__meta">Tools &middot; Computer Vision</span>
+          <h2 class="feed__title">Image Augmenter</h2>
+          <p class="feed__desc">A PyQt5 GUI that turns a single image into 1000+ augmented images.</p>
+        </a>
+      </li>
+      <li class="feed__item">
+        <a class="feed__link" href="youtube-subscriber-counter.html">
+          <span class="feed__meta">Hardware &middot; IoT</span>
+          <h2 class="feed__title">YouTube Subscriber Counter</h2>
+          <p class="feed__desc">An ESP8266 + NeoMatrix display showing live subscriber counts via the YouTube Data API.</p>
+        </a>
+      </li>
+      <li class="feed__item">
+        <a class="feed__link" href="bag-ewatch.html">
+          <span class="feed__meta">Hardware &middot; Embedded</span>
+          <h2 class="feed__title">Bag eWatch</h2>
+          <p class="feed__desc">An e-ink badge for a bag showing time plus altitude, pressure and humidity readings.</p>
+        </a>
+      </li>
+    </ul>
+  </main>
+
+  <footer class="footer">
+    <div class="container footer__inner">
+      <ul class="footer__social">
+        <li><a href="https://github.com/pranav6670" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+        <li><a href="https://www.linkedin.com/in/pranavnatekar/" target="_blank" rel="noopener noreferrer">LinkedIn</a></li>
+        <li><a href="https://twitter.com/pranavnat24" target="_blank" rel="noopener noreferrer">Twitter</a></li>
+      </ul>
+      <p class="footer__copy">&copy; 2026 Pranav Natekar</p>
+    </div>
+  </footer>
+
+  <script src="../js/site.js"></script>
+</body>
+
+</html>

--- a/projects/tabla-tala.html
+++ b/projects/tabla-tala.html
@@ -42,7 +42,6 @@
     </figure>
     <p>This project develops a system that first detects a tabla tala from a mix (a song) of Indian or Carnatic classical music, then classifies the tala. A tala is a specific rhythmic pattern present across Indian classical music, and the tabla is the percussive accompanying instrument.</p>
     <div class="article__actions">
-      <a class="btn" href="https://pranav6670.github.io/Detection-Classification-of-Tabla-taals/" target="_blank" rel="noopener noreferrer">More info</a>
       <a class="btn" href="https://github.com/pranav6670/Detection-Classification-of-Tabla-taals" target="_blank" rel="noopener noreferrer">See on GitHub</a>
     </div>
   </main>

--- a/projects/youtube-subscriber-counter.html
+++ b/projects/youtube-subscriber-counter.html
@@ -47,7 +47,6 @@
       <li>Libraries &mdash; Adafruit NeoMatrix, Adafruit NeoPixel, Adafruit GFX, ArduinoJSON, MusicEngine, SNTPtime</li>
     </ul>
     <div class="article__actions">
-      <a class="btn" href="https://pranav6670.github.io/YouTube-Sub-Count-NeoMatrix/" target="_blank" rel="noopener noreferrer">More info</a>
       <a class="btn" href="https://github.com/pranav6670/YouTube-Sub-Count-NeoMatrix" target="_blank" rel="noopener noreferrer">See on GitHub</a>
     </div>
   </main>

--- a/tests/terminal-core.test.mjs
+++ b/tests/terminal-core.test.mjs
@@ -10,7 +10,7 @@ const allText = (res) => res.lines.map(text).join("\n");
 
 test("help lists commands and hides easter eggs", () => {
   const out = allText(Core.run("help"));
-  for (const cmd of ["whoami", "projects", "open <slug>", "cd <dir>", "cat <file>", "social", "clear"])
+  for (const cmd of ["whoami", "projects", "blog", "open <slug>", "cd <page>", "cat <file>", "social", "clear"])
     assert.ok(out.includes(cmd), `help should mention ${cmd}`);
   assert.ok(!out.includes("sudo") && !out.includes("tabla"), "easter eggs hidden");
 });
@@ -44,12 +44,11 @@ test("clear → clear effect", () => {
   assert.deepEqual(Core.run("clear").effect, { type: "clear" });
 });
 
-test("cd variants (terminal-only page: no section scrolling)", () => {
+test("cd variants (real subpages: projects/ and blog/)", () => {
   assert.deepEqual(Core.run("cd").effect, { type: "scroll", target: "#top" });
   assert.deepEqual(Core.run("cd ~").effect, { type: "scroll", target: "#top" });
-  const pl = Core.run("cd projects");
-  assert.equal(pl.effect, null);
-  assert.ok(pl.lines.length >= 5, "cd projects lists the projects");
+  assert.deepEqual(Core.run("cd projects").effect, { type: "navigate", href: "projects/", newTab: false });
+  assert.deepEqual(Core.run("cd blog").effect, { type: "navigate", href: "blog/", newTab: false });
   const w = Core.run("cd writing").effect;
   assert.equal(w.type, "navigate");
   assert.ok(w.href.includes("medium.com") && w.newTab === true);
@@ -61,6 +60,14 @@ test("cd variants (terminal-only page: no section scrolling)", () => {
   const bad = Core.run("cd nope");
   assert.equal(bad.effect, null);
   assert.ok(allText(bad).includes("no such directory"));
+});
+
+test("blog command lists Medium posts", () => {
+  const res = Core.run("blog");
+  const hrefs = res.lines.flat().filter((s) => s.href).map((s) => s.href);
+  assert.ok(hrefs.filter((h) => h.includes("pranavnatekar.medium.com/")).length >= 3, "at least 3 Medium posts");
+  const out = allText(res);
+  assert.ok(out.includes("OpenCV") && out.includes("Audio Classification"));
 });
 
 test("open navigates to article pages; bare/unknown handled", () => {
@@ -101,9 +108,9 @@ test("projects lists all five with article links", () => {
     assert.ok(hrefs.some((h) => h === `projects/${slug}.html`), `missing ${slug}`);
 });
 
-test("ls shows dirs and files (no page sections anymore)", () => {
+test("ls shows page dirs and files", () => {
   const out = allText(Core.run("ls"));
-  for (const s of ["projects/", "writing/", "about.txt", ".social"]) assert.ok(out.includes(s));
+  for (const s of ["projects/", "blog/", "about.txt", ".social"]) assert.ok(out.includes(s));
   assert.ok(!out.includes("about/"), "about is a file, not a dir");
 });
 
@@ -126,6 +133,7 @@ test("completion: commands", () => {
 
 test("completion: arguments", () => {
   assert.equal(Core.complete("cd w").value, "cd writing");
+  assert.equal(Core.complete("cd b").value, "cd blog");
   assert.equal(Core.complete("cd ab").value, null, "about is not a cd target anymore");
   assert.equal(Core.complete("cd pr").value, "cd projects", "extends to common prefix");
   assert.equal(Core.complete("cat a").value, "cat about.txt");
@@ -139,7 +147,7 @@ test("intro: aleksa-style static session blocks", () => {
   const cmds = blocks.map((b) => b.cmd);
   assert.ok(cmds.includes("$ echo $GREETING"));
   assert.ok(cmds.includes("# cat /proc/status"));
-  assert.ok(cmds.includes("# ls ~/projects/"));
+  assert.ok(cmds.includes("# ls ~/pages/"));
   assert.ok(cmds.includes("# cat ~/.social"));
   const flat = blocks.flatMap((b) => b.lines);
   const txt = flat.map((l) => l.map((s) => s.text).join("")).join("\n");
@@ -147,8 +155,8 @@ test("intro: aleksa-style static session blocks", () => {
   assert.ok(txt.includes("SiFive"));
   assert.ok(txt.includes("Rochester Institute of Technology"));
   const hrefs = flat.flat().filter((s) => s.href).map((s) => s.href);
-  for (const slug of ["tabla-tala", "autonomous-vehicle", "image-augmenter", "youtube-subscriber-counter", "bag-ewatch"])
-    assert.ok(hrefs.includes(`projects/${slug}.html`), `intro missing project ${slug}`);
+  assert.ok(hrefs.includes("projects/"), "intro links the projects page");
+  assert.ok(hrefs.includes("blog/"), "intro links the blog page");
   assert.ok(hrefs.some((h) => h.includes("medium.com")));
   assert.ok(hrefs.some((h) => h.includes("github.com/pranav6670")));
   assert.ok(hrefs.some((h) => h.includes("linkedin.com")));


### PR DESCRIPTION
- projects/index.html: pi-feed listing of the five write-ups
- blog/index.html: Pranav's three Medium posts (real titles/dates/links)
- Terminal: '# ls ~/pages/' intro block links the two pages; cd projects and cd blog navigate to them (cd writing still opens Medium); new blog command lists posts inline; cat blog alias; completions + help updated
- Facts table: labels are now small muted uppercase eyebrows — rows were indistinguishable all-black mono
- Article pages: More info button removed everywhere; GitHub only