### PR TITLE
Cache-bust: version query on all CSS/JS asset URLs (?v=037d386)

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css">
+  <link rel="stylesheet" href="../css/site.css?v=037d386">
 </head>
 
 <body id="top">
@@ -65,7 +65,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js"></script>
+  <script src="../js/site.js?v=037d386"></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/site.css">
+  <link rel="stylesheet" href="css/site.css?v=037d386">
 </head>
 
 <body id="top">
@@ -57,8 +57,8 @@
     </section>
   </main>
 
-  <script src="js/terminal-core.js" defer></script>
-  <script src="js/terminal.js" defer></script>
+  <script src="js/terminal-core.js?v=037d386" defer></script>
+  <script src="js/terminal.js?v=037d386" defer></script>
 </body>
 
 </html>

--- a/projects/autonomous-vehicle.html
+++ b/projects/autonomous-vehicle.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css">
+  <link rel="stylesheet" href="../css/site.css?v=037d386">
 </head>
 
 <body id="top">
@@ -63,7 +63,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js"></script>
+  <script src="../js/site.js?v=037d386"></script>
 </body>
 
 </html>

--- a/projects/bag-ewatch.html
+++ b/projects/bag-ewatch.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css">
+  <link rel="stylesheet" href="../css/site.css?v=037d386">
 </head>
 
 <body id="top">
@@ -62,7 +62,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js"></script>
+  <script src="../js/site.js?v=037d386"></script>
 </body>
 
 </html>

--- a/projects/image-augmenter.html
+++ b/projects/image-augmenter.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css">
+  <link rel="stylesheet" href="../css/site.css?v=037d386">
 </head>
 
 <body id="top">
@@ -55,7 +55,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js"></script>
+  <script src="../js/site.js?v=037d386"></script>
 </body>
 
 </html>

--- a/projects/index.html
+++ b/projects/index.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css">
+  <link rel="stylesheet" href="../css/site.css?v=037d386">
 </head>
 
 <body id="top">
@@ -78,7 +78,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js"></script>
+  <script src="../js/site.js?v=037d386"></script>
 </body>
 
 </html>

--- a/projects/tabla-tala.html
+++ b/projects/tabla-tala.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css">
+  <link rel="stylesheet" href="../css/site.css?v=037d386">
 </head>
 
 <body id="top">
@@ -57,7 +57,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js"></script>
+  <script src="../js/site.js?v=037d386"></script>
 </body>
 
 </html>

--- a/projects/youtube-subscriber-counter.html
+++ b/projects/youtube-subscriber-counter.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css">
+  <link rel="stylesheet" href="../css/site.css?v=037d386">
 </head>
 
 <body id="top">
@@ -62,7 +62,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js"></script>
+  <script src="../js/site.js?v=037d386"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Browsers were serving stale terminal JS after each deploy; bumping the version token on asset changes forces a refetch.