### PR TITLE
Copy: Rivian on-device stack, SiFive/AMD grammar fixes

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css?v=037d386">
+  <link rel="stylesheet" href="../css/site.css?v=20260728b">
 </head>
 
 <body id="top">
@@ -65,7 +65,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js?v=037d386"></script>
+  <script src="../js/site.js?v=20260728b"></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/site.css?v=037d386">
+  <link rel="stylesheet" href="css/site.css?v=20260728b">
 </head>
 
 <body id="top">
@@ -57,8 +57,8 @@
     </section>
   </main>
 
-  <script src="js/terminal-core.js?v=037d386" defer></script>
-  <script src="js/terminal.js?v=037d386" defer></script>
+  <script src="js/terminal-core.js?v=20260728b" defer></script>
+  <script src="js/terminal.js?v=20260728b" defer></script>
 </body>
 
 </html>

--- a/js/terminal-core.js
+++ b/js/terminal-core.js
@@ -48,19 +48,20 @@
 
   var FILES = {
     "about.txt": [
-      [t("Engineer working across machine learning, computer vision and speech.")],
-      [t("I like turning newly learnt skills into real-time prototypes — the long")],
+      [t("Engineer working across machine learning, computer vision, and speech.")],
+      [t("I like turning newly learned skills into real-time prototypes — the long")],
       [t("game is intelligent cognition and reasoning in low-power machines.")],
       [t("Off the keyboard: I play the tabla.")]
     ],
     "experience.txt": [
       [t("→ Currently : Software Engineer 2, Computer Vision")],
       [t("              @ Rivian & Volkswagen Group Technologies")],
+      [t("              on-device multimodal models using LiteRT and QNN/QAIRT/SNPE")],
       [t("→ Previously:")],
-      [t("      ├── Software Engineering Intern @ AMD — inference optimization on the Ryzen NPU")],
+      [t("      ├── Software Engineering Intern @ AMD — inference optimization for the Ryzen NPU")],
       [t("      ├── EDG Intern @ MathWorks — on-device computer vision & deep learning")],
-      [t("      └── Software Engineer @ SiFive — SoC bring-up for a custom")],
-      [t("          VLIW+SIMD DSP IP and an AI accelerator")]
+      [t("      └── Software Engineer @ SiFive — custom computer vision and language")],
+      [t("          models for a VLIW+SIMD DSP IP and an AI accelerator")]
     ],
     "education.txt": [
       [t("MS, Electrical Engineering — Rochester Institute of Technology")],
@@ -80,10 +81,12 @@
   /* Static intro session (aleksa-style) rendered inside the window on load. */
   var STATUS = [
     [t("→ Currently : Software Engineer 2, Computer Vision @ Rivian & Volkswagen Group Technologies")],
+    [t("              on-device multimodal models using LiteRT and QNN/QAIRT/SNPE")],
     [t("→ Previously:")],
-    [t("      ├── Software Engineering Intern @ AMD — inference optimization on the Ryzen NPU")],
+    [t("      ├── Software Engineering Intern @ AMD — inference optimization for the Ryzen NPU")],
     [t("      ├── EDG Intern @ MathWorks — on-device computer vision & deep learning")],
-    [t("      └── Software Engineer @ SiFive — custom VLIW+SIMD DSP IP and an AI accelerator")],
+    [t("      └── Software Engineer @ SiFive — custom computer vision and language models")],
+    [t("          for a VLIW+SIMD DSP IP and an AI accelerator")],
     [t("→ Education : MS EE, Rochester Institute of Technology — CV & image processing")],
     [t("→ Research  : "), link("brain.lab @ RIT", "https://www.rit.edu/kgcoe/brainlab/"), t(" — speech tech for atypical speech")]
   ];

--- a/projects/autonomous-vehicle.html
+++ b/projects/autonomous-vehicle.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css?v=037d386">
+  <link rel="stylesheet" href="../css/site.css?v=20260728b">
 </head>
 
 <body id="top">
@@ -63,7 +63,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js?v=037d386"></script>
+  <script src="../js/site.js?v=20260728b"></script>
 </body>
 
 </html>

--- a/projects/bag-ewatch.html
+++ b/projects/bag-ewatch.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css?v=037d386">
+  <link rel="stylesheet" href="../css/site.css?v=20260728b">
 </head>
 
 <body id="top">
@@ -62,7 +62,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js?v=037d386"></script>
+  <script src="../js/site.js?v=20260728b"></script>
 </body>
 
 </html>

--- a/projects/image-augmenter.html
+++ b/projects/image-augmenter.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css?v=037d386">
+  <link rel="stylesheet" href="../css/site.css?v=20260728b">
 </head>
 
 <body id="top">
@@ -55,7 +55,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js?v=037d386"></script>
+  <script src="../js/site.js?v=20260728b"></script>
 </body>
 
 </html>

--- a/projects/index.html
+++ b/projects/index.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css?v=037d386">
+  <link rel="stylesheet" href="../css/site.css?v=20260728b">
 </head>
 
 <body id="top">
@@ -78,7 +78,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js?v=037d386"></script>
+  <script src="../js/site.js?v=20260728b"></script>
 </body>
 
 </html>

--- a/projects/tabla-tala.html
+++ b/projects/tabla-tala.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css?v=037d386">
+  <link rel="stylesheet" href="../css/site.css?v=20260728b">
 </head>
 
 <body id="top">
@@ -57,7 +57,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js?v=037d386"></script>
+  <script src="../js/site.js?v=20260728b"></script>
 </body>
 
 </html>

--- a/projects/youtube-subscriber-counter.html
+++ b/projects/youtube-subscriber-counter.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css?v=037d386">
+  <link rel="stylesheet" href="../css/site.css?v=20260728b">
 </head>
 
 <body id="top">
@@ -62,7 +62,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js?v=037d386"></script>
+  <script src="../js/site.js?v=20260728b"></script>
 </body>
 
 </html>

--- a/tests/terminal-core.test.mjs
+++ b/tests/terminal-core.test.mjs
@@ -99,8 +99,9 @@ test("topic commands mirror files", () => {
     assert.ok(Core.run(c).lines.length > 0, `${c} should print`);
   const exp = allText(Core.run("experience"));
   assert.ok(exp.includes("Software Engineer 2, Computer Vision"), "confirmed current title");
-  assert.ok(exp.includes("SiFive"));
-  assert.ok(exp.includes("Software Engineering Intern @ AMD") && exp.includes("Ryzen NPU"), "AMD internship");
+  assert.ok(exp.includes("LiteRT") && exp.includes("QNN/QAIRT/SNPE"), "Rivian on-device stack");
+  assert.ok(exp.includes("custom computer vision and language") && !exp.includes("custom VLIW"), "SiFive line without double custom");
+  assert.ok(exp.includes("inference optimization for the Ryzen NPU"), "AMD internship, 'for the'");
   assert.ok(exp.includes("EDG Intern @ MathWorks"), "MathWorks internship");
   assert.ok(allText(Core.run("education")).includes("Rochester Institute of Technology"));
 });


### PR DESCRIPTION
Rivian line gains 'on-device multimodal models using LiteRT and QNN/QAIRT/SNPE'; SiFive is now 'custom computer vision and language models for a VLIW+SIMD DSP IP and an AI accelerator' (single 'custom'); AMD reads 'inference optimization for the Ryzen NPU'; Oxford comma and 'newly learned' in about.txt. Cache token bumped to 20260728b.