### PR TITLE
Fix mobile overflow on the LocalLens page

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css?v=20260731a">
+  <link rel="stylesheet" href="../css/site.css?v=20260823a">
 </head>
 
 <body id="top">
@@ -65,7 +65,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js?v=20260731a"></script>
+  <script src="../js/site.js?v=20260823a"></script>
 </body>
 
 </html>

--- a/css/site.css
+++ b/css/site.css
@@ -115,7 +115,7 @@ h1, h2, h3, h4 {
 .article__title { font-size: clamp(2.4rem, 5vw, 3.75rem); line-height: 1.25; margin-bottom: 1.5rem; }
 .article__facts { display: grid; grid-template-columns: 7.5rem 1fr; row-gap: 0.5rem; align-items: baseline; margin: 0 0 2.5rem; font-family: var(--font-mono); font-size: 0.875rem; color: var(--fg); }
 .article__facts dt { font-size: 0.72rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); }
-.article__facts dd { margin: 0; }
+.article__facts dd { margin: 0; min-width: 0; overflow-wrap: anywhere; }
 .article__facts a { text-decoration: underline; text-underline-offset: 3px; }
 .article__facts a:hover { color: var(--muted); }
 .article__more { font-family: var(--font-mono); font-size: 0.875rem; color: var(--muted); margin-top: 2.5rem; }

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/site.css?v=20260731a">
+  <link rel="stylesheet" href="css/site.css?v=20260823a">
 </head>
 
 <body id="top">
@@ -58,8 +58,8 @@
     </section>
   </main>
 
-  <script src="js/terminal-core.js?v=20260731a" defer></script>
-  <script src="js/terminal.js?v=20260731a" defer></script>
+  <script src="js/terminal-core.js?v=20260823a" defer></script>
+  <script src="js/terminal.js?v=20260823a" defer></script>
 </body>
 
 </html>

--- a/projects/autonomous-vehicle.html
+++ b/projects/autonomous-vehicle.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css?v=20260731a">
+  <link rel="stylesheet" href="../css/site.css?v=20260823a">
 </head>
 
 <body id="top">
@@ -63,7 +63,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js?v=20260731a"></script>
+  <script src="../js/site.js?v=20260823a"></script>
 </body>
 
 </html>

--- a/projects/bag-ewatch.html
+++ b/projects/bag-ewatch.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css?v=20260731a">
+  <link rel="stylesheet" href="../css/site.css?v=20260823a">
 </head>
 
 <body id="top">
@@ -62,7 +62,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js?v=20260731a"></script>
+  <script src="../js/site.js?v=20260823a"></script>
 </body>
 
 </html>

--- a/projects/image-augmenter.html
+++ b/projects/image-augmenter.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css?v=20260731a">
+  <link rel="stylesheet" href="../css/site.css?v=20260823a">
 </head>
 
 <body id="top">
@@ -55,7 +55,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js?v=20260731a"></script>
+  <script src="../js/site.js?v=20260823a"></script>
 </body>
 
 </html>

--- a/projects/index.html
+++ b/projects/index.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css?v=20260731a">
+  <link rel="stylesheet" href="../css/site.css?v=20260823a">
 </head>
 
 <body id="top">
@@ -85,7 +85,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js?v=20260731a"></script>
+  <script src="../js/site.js?v=20260823a"></script>
 </body>
 
 </html>

--- a/projects/locallens.html
+++ b/projects/locallens.html
@@ -16,7 +16,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css?v=20260731a">
+  <link rel="stylesheet" href="../css/site.css?v=20260823a">
 </head>
 
 <body id="top">
@@ -1097,7 +1097,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js?v=20260731a"></script>
+  <script src="../js/site.js?v=20260823a"></script>
 </body>
 
 </html>

--- a/projects/tabla-tala.html
+++ b/projects/tabla-tala.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css?v=20260731a">
+  <link rel="stylesheet" href="../css/site.css?v=20260823a">
 </head>
 
 <body id="top">
@@ -57,7 +57,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js?v=20260731a"></script>
+  <script src="../js/site.js?v=20260823a"></script>
 </body>
 
 </html>

--- a/projects/youtube-subscriber-counter.html
+++ b/projects/youtube-subscriber-counter.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css?v=20260731a">
+  <link rel="stylesheet" href="../css/site.css?v=20260823a">
 </head>
 
 <body id="top">
@@ -62,7 +62,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js?v=20260731a"></script>
+  <script src="../js/site.js?v=20260823a"></script>
 </body>
 
 </html>


### PR DESCRIPTION
The facts table's unbreakable `github.com/pranav6670/LocalLens` value forced the grid's value column to its min-content width, pushing the page ~11px past small viewports (horizontal scroll on phones).

**Fix:** facts `dd` cells now shrink with the grid (`min-width: 0`) and long tokens wrap (`overflow-wrap: anywhere`). One CSS rule; applies site-wide to all article facts tables.

## Verification

- Full-page overflow audit in a real browser at **390px** and **320px**: `document.scrollWidth == viewport` (zero overflow), no offending elements; booktabs tables still scroll inside their own `article__tablewrap`.
- The GitHub URL wraps cleanly to a second line in the facts table.
- `node --test tests/terminal-core.test.mjs` — 20/20 pass. Cache token bumped to `20260823a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)