### PR TITLE
Demo videos fit on one screen (no scrolling on phones)

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css?v=20260823a">
+  <link rel="stylesheet" href="../css/site.css?v=20260823b">
 </head>
 
 <body id="top">
@@ -65,7 +65,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js?v=20260823a"></script>
+  <script src="../js/site.js?v=20260823b"></script>
 </body>
 
 </html>

--- a/css/site.css
+++ b/css/site.css
@@ -151,6 +151,10 @@ h1, h2, h3, h4 {
 .article__figure figcaption { font-family: var(--font-mono); font-size: 0.78rem; color: var(--muted); line-height: 1.5; margin-top: 0.6rem; }
 .article__figure video { width: 100%; height: auto; border-radius: 8px; display: block; }
 .article__figure--narrow { width: min(420px, 92vw); }
+/* Portrait phone recordings: fit the whole take on one screen — size by
+   viewport height (svh = with browser chrome visible), never by width. */
+.article__figure--narrow video { width: auto; max-width: 100%; margin-inline: auto; max-height: min(74vh, 660px); max-height: min(74svh, 660px); }
+.article__figure--narrow figcaption { text-align: center; }
 .article__figure--wide { width: min(1280px, 96vw); }
 .article__figure a { display: block; }
 .article__shots { display: flex; gap: 10px; justify-content: center; align-items: flex-start; }

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/site.css?v=20260823a">
+  <link rel="stylesheet" href="css/site.css?v=20260823b">
 </head>
 
 <body id="top">
@@ -58,8 +58,8 @@
     </section>
   </main>
 
-  <script src="js/terminal-core.js?v=20260823a" defer></script>
-  <script src="js/terminal.js?v=20260823a" defer></script>
+  <script src="js/terminal-core.js?v=20260823b" defer></script>
+  <script src="js/terminal.js?v=20260823b" defer></script>
 </body>
 
 </html>

--- a/projects/autonomous-vehicle.html
+++ b/projects/autonomous-vehicle.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css?v=20260823a">
+  <link rel="stylesheet" href="../css/site.css?v=20260823b">
 </head>
 
 <body id="top">
@@ -63,7 +63,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js?v=20260823a"></script>
+  <script src="../js/site.js?v=20260823b"></script>
 </body>
 
 </html>

--- a/projects/bag-ewatch.html
+++ b/projects/bag-ewatch.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css?v=20260823a">
+  <link rel="stylesheet" href="../css/site.css?v=20260823b">
 </head>
 
 <body id="top">
@@ -62,7 +62,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js?v=20260823a"></script>
+  <script src="../js/site.js?v=20260823b"></script>
 </body>
 
 </html>

--- a/projects/image-augmenter.html
+++ b/projects/image-augmenter.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css?v=20260823a">
+  <link rel="stylesheet" href="../css/site.css?v=20260823b">
 </head>
 
 <body id="top">
@@ -55,7 +55,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js?v=20260823a"></script>
+  <script src="../js/site.js?v=20260823b"></script>
 </body>
 
 </html>

--- a/projects/index.html
+++ b/projects/index.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css?v=20260823a">
+  <link rel="stylesheet" href="../css/site.css?v=20260823b">
 </head>
 
 <body id="top">
@@ -85,7 +85,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js?v=20260823a"></script>
+  <script src="../js/site.js?v=20260823b"></script>
 </body>
 
 </html>

--- a/projects/locallens.html
+++ b/projects/locallens.html
@@ -16,7 +16,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css?v=20260823a">
+  <link rel="stylesheet" href="../css/site.css?v=20260823b">
 </head>
 
 <body id="top">
@@ -1097,7 +1097,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js?v=20260823a"></script>
+  <script src="../js/site.js?v=20260823b"></script>
 </body>
 
 </html>

--- a/projects/tabla-tala.html
+++ b/projects/tabla-tala.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css?v=20260823a">
+  <link rel="stylesheet" href="../css/site.css?v=20260823b">
 </head>
 
 <body id="top">
@@ -57,7 +57,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js?v=20260823a"></script>
+  <script src="../js/site.js?v=20260823b"></script>
 </body>
 
 </html>

--- a/projects/youtube-subscriber-counter.html
+++ b/projects/youtube-subscriber-counter.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/site.css?v=20260823a">
+  <link rel="stylesheet" href="../css/site.css?v=20260823b">
 </head>
 
 <body id="top">
@@ -62,7 +62,7 @@
     </div>
   </footer>
 
-  <script src="../js/site.js?v=20260823a"></script>
+  <script src="../js/site.js?v=20260823b"></script>
 </body>
 
 </html>


### PR DESCRIPTION
The two portrait screen recordings on the LocalLens page (656×1428) were sized by column width, making them ~800px tall on phones — taller than the visible viewport, so you had to scroll mid-video.

**Fix:** videos in narrow figures are now sized by viewport height instead: `max-height: min(74svh, 660px)`, width auto, horizontally centered, with the caption centered beneath. `svh` accounts for mobile browser chrome, so the whole take + caption fit on one screen even with Safari's bars visible.

## Verification

- 402×874 (iPhone 17 Pro CSS viewport): both videos render 297×647, fully on screen with caption, centered
- 1440×900 desktop: 303×660, fully on screen
- `node --test tests/terminal-core.test.mjs` — 20/20 pass; cache token `20260823b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)